### PR TITLE
Add support for API 2.1 calls

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,32 +9,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -59,7 +59,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1130,16 +1130,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46"
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0938408c4faa518d95230deabb5f595bf0de31b9",
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9",
                 "shasum": ""
             },
             "require": {
@@ -1181,7 +1181,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-05T14:43:42+00:00"
+            "time": "2017-11-10T18:26:04+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Oauth.php
+++ b/src/Oauth.php
@@ -22,7 +22,13 @@ class Oauth
     const HOSTNAME    = 'orcid.org';
     const AUTHORIZE   = 'oauth/authorize';
     const TOKEN       = 'oauth/token';
-    const API_VERSION = '2.0';
+
+    /**
+     * update the ORCID API default to 2.1. This is functionally equivalent to 2.0 but forces
+     * all connections through https by default. All of the connection endpoints already used https,
+     * so this is quite a short job.
+     **/
+    const API_VERSION = '2.1';
 
     /**
      * The http tranport object
@@ -43,7 +49,7 @@ class Oauth
      *
      * @var  string
      **/
-    private $api_version = '2.0';
+    //private API_VERSION = self::API_VERSION;
 
     /**
      * The ORCID environment type
@@ -488,9 +494,9 @@ class Oauth
      * @return  object
      * @throws  Exception
      **/
-    public function getProfile($orcid = null, $api_version = '2.0')
+    public function getProfile($orcid = null, $api_version = self::API_VERSION)
     {
-        if ($api_version === '2.0') {
+        if ($api_version >= '2.0') {
             $this->http->setUrl($this->getApiEndpoint('record', $api_version, $orcid));
         } else {
             $this->http->setUrl($this->getApiEndpoint('orcid-profile', $api_version, $orcid));
@@ -521,9 +527,9 @@ class Oauth
      * @param   string  $orcid        the orcid to look up, if not already specified
      * @return  string
      **/
-    public function getApiEndpoint($endpoint, $api_version = "2.0", $orcid = null)
+    public function getApiEndpoint($endpoint, $api_version = self::API_VERSION, $orcid = null)
     {
-        $allowed_api_versions = array('1.2', '2.0');
+        $allowed_api_versions = array('1.2', '2.0', '2.1');
         if (!in_array($api_version, $allowed_api_versions)) {
             $version = $this->api_version;
         }

--- a/tests/OauthTest.php
+++ b/tests/OauthTest.php
@@ -386,7 +386,7 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
              ->getMock()
              ->shouldReceive('setUrl')
              ->once()
-             ->with('https://pub.orcid.org/v2.0/0000-0000-0000-0000/record');
+             ->with('https://pub.orcid.org/v2.1/0000-0000-0000-0000/record');
 
         $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
         $oauth->getProfile('0000-0000-0000-0000');
@@ -404,7 +404,7 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
              ->getMock()
              ->shouldReceive('setUrl')
              ->once()
-             ->with('https://pub.orcid.org/v2.0/0000-0000-0000-0000/record');
+             ->with('https://pub.orcid.org/v2.1/0000-0000-0000-0000/record');
 
         $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
         $oauth->usePublicApi()->setOrcid('0000-0000-0000-0000')->getProfile();
@@ -422,7 +422,7 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
              ->getMock()
              ->shouldReceive('setUrl')
              ->once()
-             ->with('https://api.orcid.org/v2.0/0000-0000-0000-0000/record');
+             ->with('https://api.orcid.org/v2.1/0000-0000-0000-0000/record');
 
         $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
         $oauth->useMembersApi()
@@ -444,10 +444,10 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
              ->getMock()
              ->shouldReceive('setUrl')
              ->once()
-             ->with('https://api.orcid.org/v2.0/0000-0000-0000-0000/record');
+             ->with('https://api.orcid.org/v2.1/0000-0000-0000-0000/record');
 
         $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
-        $oauth->useMembersApi()->getProfile('0000-0000-0000-0000', '2.0');
+        $oauth->useMembersApi()->getProfile('0000-0000-0000-0000', '2.1');
     }
 
     /**
@@ -455,7 +455,7 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
      *
      * @return  void
      **/
-    public function testGetMemberSandboxProfileUsesProperUrl()
+    public function testGetMemberSandboxProfileUsesProper20Url()
     {
         $http = m::mock('Orcid\Http\Curl');
         $http->shouldReceive('execute', 'setHeader', 'setOpt')->andReturn(m::self())
@@ -476,7 +476,28 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
      *
      * @return  void
      **/
-    public function testGetPublicSandboxProfileUsesProperUrl()
+    public function testGetMemberSandboxProfileUsesProper21Url()
+    {
+        $http = m::mock('Orcid\Http\Curl');
+        $http->shouldReceive('execute', 'setHeader', 'setOpt')->andReturn(m::self())
+             ->getMock()
+             ->shouldReceive('setUrl')
+             ->once()
+             ->with('https://api.sandbox.orcid.org/v2.1/0000-0000-0000-0000/record');
+
+        $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
+        $oauth->useMembersApi()
+              ->useSandboxEnvironment()
+              ->setAccessToken('123456789')
+              ->getProfile('0000-0000-0000-0000', '2.1');
+    }
+
+    /**
+     * Test to make we use the proper sandbox url when fetching a sandbox profile
+     *
+     * @return  void
+     **/
+    public function testGetPublicSandboxProfileUsesProper20Url()
     {
         $http = m::mock('Orcid\Http\Curl');
         $http->shouldReceive('execute', 'setHeader', 'setOpt')->andReturn(m::self())
@@ -490,5 +511,26 @@ class OauthTest extends m\Adapter\Phpunit\MockeryTestCase
               ->useSandboxEnvironment()
               ->setAccessToken('123456789')
               ->getProfile('0000-0000-0000-0000', '2.0');
+    }
+
+    /**
+     * Test to make we use the proper sandbox url when fetching a sandbox profile
+     *
+     * @return  void
+     **/
+    public function testGetPublicSandboxProfileUsesProper21Url()
+    {
+        $http = m::mock('Orcid\Http\Curl');
+        $http->shouldReceive('execute', 'setHeader', 'setOpt')->andReturn(m::self())
+             ->getMock()
+             ->shouldReceive('setUrl')
+             ->once()
+             ->with('https://pub.sandbox.orcid.org/v2.1/0000-0000-0000-0000/record');
+
+        $oauth = m::mock('Orcid\Oauth', [$http])->makePartial();
+        $oauth->usePublicApi()
+              ->useSandboxEnvironment()
+              ->setAccessToken('123456789')
+              ->getProfile('0000-0000-0000-0000', '2.1');
     }
 }


### PR DESCRIPTION
API 2.1 forces https calls. This shouldn't affect things here as all the endpoint calls were made with https anyway, but added for completeness.